### PR TITLE
Runtime mutation cleanup of the Engine

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -94,18 +94,11 @@
       <code><![CDATA[private function parse(string $source): array]]></code>
     </InvalidDocblock>
     <InvalidStringClass>
-      <code><![CDATA[new $className($this)]]></code>
+      <code><![CDATA[new $className($this, $this->helpers)]]></code>
     </InvalidStringClass>
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->templates[$className]]]></code>
     </LessSpecificReturnStatement>
-    <MixedAssignment>
-      <code><![CDATA[$helper]]></code>
-    </MixedAssignment>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->helpers]]></code>
-      <code><![CDATA[$this->helpers]]></code>
-    </MixedReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[Template]]></code>
     </MoreSpecificReturnType>
@@ -114,7 +107,6 @@
     </NoValue>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$escape]]></code>
-      <code><![CDATA[$helpers]]></code>
     </PropertyNotSetInConstructor>
     <PropertyTypeCoercion>
       <code><![CDATA[$this->templates]]></code>
@@ -388,26 +380,6 @@
       <code><![CDATA[$info['extension']]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
-  <file src="test/Mustache/Test/Functional/FiltersTest.php">
-    <MissingClosureParamType>
-      <code><![CDATA[$v]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[static function ($value) {]]></code>
-      <code><![CDATA[static function ($value) {]]></code>
-      <code><![CDATA[static function (DateTime $value) {]]></code>
-    </MissingClosureReturnType>
-    <MixedArgument>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
-  </file>
   <file src="test/Mustache/Test/Functional/HigherOrderSections/Foo.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[staticTrim]]></code>
@@ -525,9 +497,6 @@
     <MixedAssignment>
       <code><![CDATA[$args]]></code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getFoo]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="test/Mustache/Test/Loader/FilesystemLoaderTest.php">
     <InvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -136,9 +136,6 @@
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$this->delimiters]]></code>
     </RiskyTruthyFalsyComparison>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[getLogger]]></code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/HelperCollection.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -93,59 +93,25 @@
     <InvalidDocblock>
       <code><![CDATA[private function parse(string $source): array]]></code>
     </InvalidDocblock>
-    <InvalidNullableReturnType>
-      <code><![CDATA[Cache]]></code>
-    </InvalidNullableReturnType>
     <InvalidStringClass>
       <code><![CDATA[new $className($this)]]></code>
     </InvalidStringClass>
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->templates[$className]]]></code>
     </LessSpecificReturnStatement>
-    <MixedArgument>
-      <code><![CDATA[$cache]]></code>
-      <code><![CDATA[$mode]]></code>
-      <code><![CDATA[$options['helpers']]]></code>
-      <code><![CDATA[$options['loader']]]></code>
-      <code><![CDATA[$options['logger']]]></code>
-      <code><![CDATA[$options['partials']]]></code>
-      <code><![CDATA[$options['partials_loader']]]></code>
-      <code><![CDATA[$pragma]]></code>
-    </MixedArgument>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->pragmas[$pragma]]]></code>
-      <code><![CDATA[self::$knownPragmas[$pragma]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
-      <code><![CDATA[$cache]]></code>
       <code><![CDATA[$helper]]></code>
-      <code><![CDATA[$mode]]></code>
-      <code><![CDATA[$pragma]]></code>
-      <code><![CDATA[$this->charset]]></code>
-      <code><![CDATA[$this->delimiters]]></code>
-      <code><![CDATA[$this->entityFlags]]></code>
-      <code><![CDATA[$this->strictCallables]]></code>
-      <code><![CDATA[$this->templateClassPrefix]]></code>
     </MixedAssignment>
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[$this->pragmas]]></code>
-    </MixedPropertyTypeCoercion>
     <MixedReturnStatement>
-      <code><![CDATA[$this->cache]]></code>
       <code><![CDATA[$this->helpers]]></code>
       <code><![CDATA[$this->helpers]]></code>
     </MixedReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[Template]]></code>
     </MoreSpecificReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->cache]]></code>
-    </NullableReturnStatement>
     <PropertyNotSetInConstructor>
-      <code><![CDATA[$cache]]></code>
       <code><![CDATA[$escape]]></code>
       <code><![CDATA[$helpers]]></code>
-      <code><![CDATA[$lambdaCache]]></code>
       <code><![CDATA[$loader]]></code>
       <code><![CDATA[$partialsLoader]]></code>
     </PropertyNotSetInConstructor>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -150,7 +150,6 @@
       <code><![CDATA[$loader]]></code>
       <code><![CDATA[$parser]]></code>
       <code><![CDATA[$partialsLoader]]></code>
-      <code><![CDATA[$tokenizer]]></code>
     </PropertyNotSetInConstructor>
     <PropertyTypeCoercion>
       <code><![CDATA[$this->templates]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -115,23 +115,13 @@
     <PropertyNotSetInConstructor>
       <code><![CDATA[$escape]]></code>
       <code><![CDATA[$helpers]]></code>
-      <code><![CDATA[$loader]]></code>
-      <code><![CDATA[$partialsLoader]]></code>
     </PropertyNotSetInConstructor>
     <PropertyTypeCoercion>
       <code><![CDATA[$this->templates]]></code>
     </PropertyTypeCoercion>
-    <RedundantCondition>
-      <code><![CDATA[isset($this->loader) && ! $this->loader instanceof StringLoader]]></code>
-    </RedundantCondition>
     <RedundantPropertyInitializationCheck>
       <code><![CDATA['default']]></code>
       <code><![CDATA[isset($this->escape)]]></code>
-      <code><![CDATA[isset($this->loader)]]></code>
-      <code><![CDATA[isset($this->loader)]]></code>
-      <code><![CDATA[isset($this->partialsLoader)]]></code>
-      <code><![CDATA[isset($this->partialsLoader)]]></code>
-      <code><![CDATA[isset($this->partialsLoader)]]></code>
     </RedundantPropertyInitializationCheck>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$this->delimiters]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -109,6 +109,9 @@
     <MoreSpecificReturnType>
       <code><![CDATA[Template]]></code>
     </MoreSpecificReturnType>
+    <NoValue>
+      <code><![CDATA[$pragma]]></code>
+    </NoValue>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$escape]]></code>
       <code><![CDATA[$helpers]]></code>
@@ -134,7 +137,6 @@
       <code><![CDATA[$this->delimiters]]></code>
     </RiskyTruthyFalsyComparison>
     <UndefinedInterfaceMethod>
-      <code><![CDATA[getLogger]]></code>
       <code><![CDATA[getLogger]]></code>
     </UndefinedInterfaceMethod>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -148,7 +148,6 @@
       <code><![CDATA[$helpers]]></code>
       <code><![CDATA[$lambdaCache]]></code>
       <code><![CDATA[$loader]]></code>
-      <code><![CDATA[$parser]]></code>
       <code><![CDATA[$partialsLoader]]></code>
     </PropertyNotSetInConstructor>
     <PropertyTypeCoercion>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -93,31 +93,16 @@
     <InvalidDocblock>
       <code><![CDATA[private function parse(string $source): array]]></code>
     </InvalidDocblock>
-    <InvalidStringClass>
-      <code><![CDATA[new $className($this, $this->helpers)]]></code>
-    </InvalidStringClass>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$this->templates[$className]]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[Template]]></code>
-    </MoreSpecificReturnType>
     <NoValue>
       <code><![CDATA[$pragma]]></code>
     </NoValue>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$escape]]></code>
     </PropertyNotSetInConstructor>
-    <PropertyTypeCoercion>
-      <code><![CDATA[$this->templates]]></code>
-    </PropertyTypeCoercion>
     <RedundantPropertyInitializationCheck>
       <code><![CDATA['default']]></code>
       <code><![CDATA[isset($this->escape)]]></code>
     </RedundantPropertyInitializationCheck>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$this->delimiters]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/HelperCollection.php">
     <MixedAssignment>
@@ -132,21 +117,7 @@
       <code><![CDATA[(string) $string]]></code>
     </RedundantCast>
   </file>
-  <file src="src/Loader/FilesystemLoader.php">
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->templates]]></code>
-    </InvalidPropertyAssignmentValue>
-  </file>
   <file src="src/Loader/InlineLoader.php">
-    <InvalidNullableReturnType>
-      <code><![CDATA[string|Source]]></code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->templates[$name]]]></code>
-    </NullableReturnStatement>
-    <PossiblyNullArgument>
-      <code><![CDATA[$this->templates]]></code>
-    </PossiblyNullArgument>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$content]]></code>
     </PossiblyUndefinedArrayOffset>
@@ -233,18 +204,9 @@
     </PropertyTypeCoercion>
   </file>
   <file src="src/Source/FilesystemSource.php">
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[stat($this->fileName)]]></code>
-    </InvalidPropertyAssignmentValue>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[string]]></code>
     </PossiblyUnusedReturnValue>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$stat]]></code>
-    </PropertyNotSetInConstructor>
-    <RedundantPropertyInitializationCheck>
-      <code><![CDATA[isset($this->stat)]]></code>
-    </RedundantPropertyInitializationCheck>
   </file>
   <file src="src/Template.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -143,7 +143,6 @@
     </NullableReturnStatement>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$cache]]></code>
-      <code><![CDATA[$compiler]]></code>
       <code><![CDATA[$escape]]></code>
       <code><![CDATA[$helpers]]></code>
       <code><![CDATA[$lambdaCache]]></code>

--- a/src/Cache/FilesystemCache.php
+++ b/src/Cache/FilesystemCache.php
@@ -29,7 +29,7 @@ use function umask;
  *
  * The FilesystemCache benefits from any opcode caching that may be setup in your environment. So do that, k?
  */
-class FilesystemCache extends AbstractCache
+final class FilesystemCache extends AbstractCache
 {
     /**
      * Filesystem cache constructor.

--- a/src/Cache/NoopCache.php
+++ b/src/Cache/NoopCache.php
@@ -12,7 +12,7 @@ use Psr\Log\LogLevel;
  * The in-memory cache is used for uncached lambda section templates. It's also useful during development, but is not
  * recommended for production use.
  */
-class NoopCache extends AbstractCache
+final class NoopCache extends AbstractCache
 {
     /**
      * Loads nothing. Move along.

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -26,7 +26,7 @@ use const ENT_COMPAT;
  *
  * This class is responsible for turning a Mustache token parse tree into normal PHP source code.
  */
-class Compiler
+final class Compiler
 {
     private const PARTIAL_INDENT = ', $indent . %s';
     private const PARTIAL = '

--- a/src/Context.php
+++ b/src/Context.php
@@ -23,7 +23,7 @@ use function sprintf;
 /**
  * Mustache Template rendering Context.
  */
-class Context
+final class Context
 {
     /** @var list<mixed> */
     private array $stack = [];

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -74,7 +74,7 @@ class Engine
     private bool $buggyPropertyShadowing = false;
     // Services
     private Tokenizer $tokenizer;
-    private Parser|null $parser;
+    private Parser $parser;
     private Compiler|null $compiler;
 
     /**
@@ -157,6 +157,7 @@ class Engine
     public function __construct(array $options = [])
     {
         $this->tokenizer = new Tokenizer();
+        $this->parser = new Parser();
 
         if (isset($options['template_class_prefix'])) {
             if ((string) $options['template_class_prefix'] === '') {
@@ -462,28 +463,6 @@ class Engine
     }
 
     /**
-     * Set the Mustache Parser instance.
-     */
-    public function setParser(Parser $parser): void
-    {
-        $this->parser = $parser;
-    }
-
-    /**
-     * Get the current Mustache Parser instance.
-     *
-     * If no Parser instance has been explicitly specified, this method will instantiate and return a new one.
-     */
-    public function getParser(): Parser
-    {
-        if (! isset($this->parser)) {
-            $this->parser = new Parser();
-        }
-
-        return $this->parser;
-    }
-
-    /**
      * Set the Mustache Compiler instance.
      */
     public function setCompiler(Compiler $compiler): void
@@ -705,10 +684,9 @@ class Engine
      */
     private function parse(string $source): array
     {
-        $parser = $this->getParser();
-        $parser->setPragmas($this->getPragmas());
+        $this->parser->setPragmas($this->getPragmas());
 
-        return $parser->parse($this->tokenize($source));
+        return $this->parser->parse($this->tokenize($source));
     }
 
     /**

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -14,6 +14,7 @@ use Mustache\Loader\StringLoader;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
+use function array_key_exists;
 use function array_keys;
 use function class_exists;
 use function is_callable;
@@ -59,9 +60,7 @@ class Engine
     public const PRAGMA_BLOCKS = 'BLOCKS';
     public const PRAGMA_ANCHORED_DOT = 'ANCHORED-DOT';
     public const PRAGMA_DYNAMIC_NAMES = 'DYNAMIC-NAMES';
-    // Known pragmas
-    /** @var array<string, bool> */
-    private static array $knownPragmas = [
+    private const KNOWN_PRAGMAS = [
         self::PRAGMA_FILTERS => true,
         self::PRAGMA_BLOCKS => true,
         self::PRAGMA_ANCHORED_DOT => true,
@@ -231,14 +230,13 @@ class Engine
             $this->delimiters = $options['delimiters'];
         }
 
-        if (isset($options['pragmas'])) {
-            foreach ($options['pragmas'] as $pragma) {
-                if (! isset(self::$knownPragmas[$pragma])) {
-                    throw new InvalidArgumentException(sprintf('Unknown pragma: "%s".', $pragma));
-                }
-
-                $this->pragmas[$pragma] = true;
+        $pragmas = $options['pragmas'] ?? [];
+        foreach ($pragmas as $pragma) {
+            if (! array_key_exists($pragma, self::KNOWN_PRAGMAS)) {
+                throw new InvalidArgumentException(sprintf('Unknown pragma: "%s".', $pragma));
             }
+
+            $this->pragmas[$pragma] = true;
         }
 
         $this->buggyPropertyShadowing = $options['buggy_property_shadowing'] ?? false;
@@ -300,7 +298,7 @@ class Engine
      *
      * @return list<self::PRAGMA_*>
      */
-    public function getPragmas(): array
+    private function getPragmas(): array
     {
         return array_keys($this->pragmas);
     }

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -75,7 +75,7 @@ class Engine
     // Services
     private Tokenizer $tokenizer;
     private Parser $parser;
-    private Compiler|null $compiler;
+    private Compiler $compiler;
 
     /**
      * Mustache class constructor.
@@ -158,6 +158,7 @@ class Engine
     {
         $this->tokenizer = new Tokenizer();
         $this->parser = new Parser();
+        $this->compiler = new Compiler();
 
         if (isset($options['template_class_prefix'])) {
             if ((string) $options['template_class_prefix'] === '') {
@@ -463,28 +464,6 @@ class Engine
     }
 
     /**
-     * Set the Mustache Compiler instance.
-     */
-    public function setCompiler(Compiler $compiler): void
-    {
-        $this->compiler = $compiler;
-    }
-
-    /**
-     * Get the current Mustache Compiler instance.
-     *
-     * If no Compiler instance has been explicitly specified, this method will instantiate and return a new one.
-     */
-    public function getCompiler(): Compiler
-    {
-        if (! isset($this->compiler)) {
-            $this->compiler = new Compiler();
-        }
-
-        return $this->compiler;
-    }
-
-    /**
      * Set the Mustache Cache instance.
      */
     public function setCache(Cache $cache): void
@@ -712,10 +691,9 @@ class Engine
 
         $tree = $this->parse($source);
 
-        $compiler = $this->getCompiler();
-        $compiler->setPragmas($this->getPragmas());
+        $this->compiler->setPragmas($this->getPragmas());
 
-        return $compiler->compile(
+        return $this->compiler->compile(
             $source,
             $tree,
             $name,

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -466,7 +466,11 @@ class Engine
                 ['className' => $className],
             );
 
-            $this->templates[$className] = new $className($this, $this->helpers);
+            $this->templates[$className] = new $className(
+                $this,
+                $this->helpers,
+                $this->strictCallables,
+            );
         }
 
         return $this->templates[$className];

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -85,7 +85,7 @@ class Engine
     private readonly int $entityFlags;
     private string $charset = 'UTF-8';
     private readonly LoggerInterface|null $logger;
-    private bool $strictCallables = false;
+    private readonly bool $strictCallables;
     /** @var array<self::PRAGMA_*, bool> */
     private array $pragmas = [];
     private string|null $delimiters = null;
@@ -220,9 +220,7 @@ class Engine
             $this->charset = $options['charset'];
         }
 
-        if (isset($options['strict_callables'])) {
-            $this->strictCallables = $options['strict_callables'];
-        }
+        $this->strictCallables = $options['strict_callables'] ?? true;
 
         if (isset($options['delimiters'])) {
             $this->delimiters = $options['delimiters'];

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -73,7 +73,7 @@ class Engine
     private string|null $delimiters = null;
     private bool $buggyPropertyShadowing = false;
     // Services
-    private Tokenizer|null $tokenizer;
+    private Tokenizer $tokenizer;
     private Parser|null $parser;
     private Compiler|null $compiler;
 
@@ -156,6 +156,8 @@ class Engine
      */
     public function __construct(array $options = [])
     {
+        $this->tokenizer = new Tokenizer();
+
         if (isset($options['template_class_prefix'])) {
             if ((string) $options['template_class_prefix'] === '') {
                 throw new InvalidArgumentException('Mustache Constructor "template_class_prefix" must not be empty');
@@ -460,28 +462,6 @@ class Engine
     }
 
     /**
-     * Set the Mustache Tokenizer instance.
-     */
-    public function setTokenizer(Tokenizer $tokenizer): void
-    {
-        $this->tokenizer = $tokenizer;
-    }
-
-    /**
-     * Get the current Mustache Tokenizer instance.
-     *
-     * If no Tokenizer instance has been explicitly specified, this method will instantiate and return a new one.
-     */
-    public function getTokenizer(): Tokenizer
-    {
-        if (! isset($this->tokenizer)) {
-            $this->tokenizer = new Tokenizer();
-        }
-
-        return $this->tokenizer;
-    }
-
-    /**
      * Set the Mustache Parser instance.
      */
     public function setParser(Parser $parser): void
@@ -713,7 +693,7 @@ class Engine
      */
     private function tokenize(string $source): array
     {
-        return $this->getTokenizer()->scan($source, $this->delimiters);
+        return $this->tokenizer->scan($source, $this->delimiters);
     }
 
     /**

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -70,7 +70,7 @@ class Engine
         self::PRAGMA_DYNAMIC_NAMES => true,
     ];
     // Mustache\Template cache
-    /** @var array<class-string, Template> */
+    /** @var array<class-string<Template>, Template> */
     private array $templates = [];
     // Environment
     private string $templateClassPrefix = '__Mustache_';
@@ -362,7 +362,7 @@ class Engine
         // Keep this list in alphabetical order :)
         $chunks = [
             'charset' => $this->charset,
-            'delimiters' => $this->delimiters ?: '{{ }}',
+            'delimiters' => $this->delimiters ?? '{{ }}',
             'entityFlags' => $this->entityFlags,
             'escape' => isset($this->escape) ? 'custom' : 'default',
             'key' => $source instanceof Source ? $source->getKey() : 'source',
@@ -448,6 +448,7 @@ class Engine
      */
     private function loadSource(string|Source $source, Cache|null $cache = null): Template
     {
+        /** @psalm-var class-string<Template> $className */
         $className = $this->getTemplateClassName($source);
 
         if (! isset($this->templates[$className])) {

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -23,7 +23,9 @@ use function json_encode;
 use function md5;
 use function sprintf;
 
-use const ENT_COMPAT;
+use const ENT_HTML401;
+use const ENT_QUOTES;
+use const ENT_SUBSTITUTE;
 
 /**
  * A Mustache implementation in PHP.
@@ -72,26 +74,26 @@ class Engine
     private array $templates = [];
     // Environment
     private string $templateClassPrefix = '__Mustache_';
-    private Cache $cache;
+    private readonly Cache $cache;
     private Cache|null $lambdaCache = null;
     private bool $cacheLambdaTemplates = false;
-    private Loader $loader;
+    private readonly Loader $loader;
     private Loader|null $partialsLoader;
     private HelperCollection|null $helpers;
     /** @var callable */
     private $escape;
-    private int $entityFlags = ENT_COMPAT;
+    private readonly int $entityFlags;
     private string $charset = 'UTF-8';
-    private LoggerInterface|null $logger;
+    private readonly LoggerInterface|null $logger;
     private bool $strictCallables = false;
     /** @var array<self::PRAGMA_*, bool> */
     private array $pragmas = [];
     private string|null $delimiters = null;
     private bool $buggyPropertyShadowing = false;
     // Services
-    private Tokenizer $tokenizer;
-    private Parser $parser;
-    private Compiler $compiler;
+    private readonly Tokenizer $tokenizer;
+    private readonly Parser $parser;
+    private readonly Compiler $compiler;
 
     /**
      * Mustache class constructor.
@@ -212,9 +214,7 @@ class Engine
             $this->escape = $options['escape'];
         }
 
-        if (isset($options['entity_flags'])) {
-            $this->entityFlags = $options['entity_flags'];
-        }
+        $this->entityFlags = $options['entity_flags'] ?? ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401;
 
         if (isset($options['charset'])) {
             $this->charset = $options['charset'];
@@ -263,14 +263,6 @@ class Engine
     public function getEscape(): callable|null
     {
         return $this->escape;
-    }
-
-    /**
-     * Get the current Mustache entitity type to escape.
-     */
-    public function getEntityFlags(): int
-    {
-        return $this->entityFlags;
     }
 
     /**

--- a/src/HelperCollection.php
+++ b/src/HelperCollection.php
@@ -22,16 +22,12 @@ class HelperCollection
      *
      * Optionally accepts an array (or Traversable) of `$name => $helper` pairs.
      *
-     * @param iterable<string, mixed> $helpers (default: null)
+     * @param iterable<string, mixed> $helpers
      *
      * @throws InvalidArgumentException if the $helpers argument isn't an array or Traversable.
      */
-    public function __construct(iterable|null $helpers = null)
+    public function __construct(iterable $helpers = [])
     {
-        if ($helpers === null) {
-            return;
-        }
-
         foreach ($helpers as $name => $helper) {
             $this->add($name, $helper);
         }

--- a/src/HelperCollection.php
+++ b/src/HelperCollection.php
@@ -12,7 +12,7 @@ use function array_key_exists;
 /**
  * A collection of helpers for a Mustache instance.
  */
-class HelperCollection
+final class HelperCollection
 {
     /** @var array<string, mixed> */
     private array $helpers = [];

--- a/src/LambdaHelper.php
+++ b/src/LambdaHelper.php
@@ -11,7 +11,7 @@ namespace Mustache;
  * giving them access to a `render` method for rendering a string with the
  * current context.
  */
-class LambdaHelper
+final class LambdaHelper
 {
     /**
      * Mustache Lambda Helper constructor.

--- a/src/Loader/ArrayLoader.php
+++ b/src/Loader/ArrayLoader.php
@@ -23,7 +23,7 @@ use Mustache\Source;
  * The ArrayLoader is used internally as a partials loader by Mustache_Engine instance when an array of partials
  * is set. It can also be used as a quick-and-dirty Template loader.
  */
-class ArrayLoader implements Loader, MutableLoader
+final class ArrayLoader implements Loader, MutableLoader
 {
     /** @param array<string, string> $templates Associative array of Template source (default: []) */
     public function __construct(private array $templates = [])

--- a/src/Loader/CascadingLoader.php
+++ b/src/Loader/CascadingLoader.php
@@ -12,7 +12,7 @@ use Mustache\Source;
  * A Mustache Template cascading loader implementation, which delegates to other
  * Loader instances.
  */
-class CascadingLoader implements Loader
+final class CascadingLoader implements Loader
 {
     /** @var list<Loader> */
     private array $loaders;

--- a/src/Loader/FilesystemLoader.php
+++ b/src/Loader/FilesystemLoader.php
@@ -39,7 +39,7 @@ class FilesystemLoader implements Loader
 {
     private string $baseDir;
     private string $extension = '.mustache';
-    /** @var array<string, string> */
+    /** @var array<string, string|Source> */
     private array $templates = [];
 
     /**

--- a/src/Loader/ProductionFilesystemLoader.php
+++ b/src/Loader/ProductionFilesystemLoader.php
@@ -19,7 +19,7 @@ use function file_exists;
  *
  * {@inheritDoc}
  */
-class ProductionFilesystemLoader extends FilesystemLoader
+final class ProductionFilesystemLoader extends FilesystemLoader
 {
     /** @var list<string> */
     private array $statProps;

--- a/src/Loader/StringLoader.php
+++ b/src/Loader/StringLoader.php
@@ -21,7 +21,7 @@ use Mustache\Source;
  *     $tpl = $m->loadTemplate('{{ foo }}');
  *     echo $tpl->render(array('foo' => 'bar')); // "bar"
  */
-class StringLoader implements Loader
+final class StringLoader implements Loader
 {
     public function load(string $name): string|Source
     {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -24,7 +24,7 @@ use function substr;
  *
  * This class is responsible for turning a set of Mustache tokens into a parse tree.
  */
-class Parser
+final class Parser
 {
     private int $lineNum = -1;
     private int $lineTokens = 0;

--- a/src/Source/FilesystemSource.php
+++ b/src/Source/FilesystemSource.php
@@ -20,18 +20,20 @@ use function stat;
  * It is more suitable for production use, and is used by default in the
  * ProductionFilesystemLoader.
  */
-class FilesystemSource implements Source
+final class FilesystemSource implements Source
 {
-    /** @var array<string, int>|false */
-    private array|false $stat;
+    /** @var array<array-key, int>|null */
+    private array|null $stat = null;
 
     /**
      * Filesystem Source constructor.
      *
      * @param list<string> $statProps
      */
-    public function __construct(private string $fileName, private array $statProps)
-    {
+    public function __construct(
+        private readonly string $fileName,
+        private readonly array $statProps,
+    ) {
     }
 
     /**
@@ -46,13 +48,16 @@ class FilesystemSource implements Source
         ];
 
         if (! empty($this->statProps)) {
-            if (! isset($this->stat)) {
-                $this->stat = stat($this->fileName);
+            $stat = $this->stat;
+            if ($stat === null) {
+                $stat = stat($this->fileName);
             }
 
-            if ($this->stat === false) {
+            if ($stat === false) {
                 throw new RuntimeException(sprintf('Failed to read source file "%s".', $this->fileName));
             }
+
+            $this->stat = $stat;
 
             foreach ($this->statProps as $prop) {
                 $chunks[$prop] = $this->stat[$prop];

--- a/src/Template.php
+++ b/src/Template.php
@@ -24,8 +24,10 @@ abstract class Template
     /**
      * Mustache Template constructor.
      */
-    public function __construct(protected Engine $mustache)
-    {
+    public function __construct(
+        protected Engine $mustache,
+        protected HelperCollection $helpers,
+    ) {
     }
 
     /**
@@ -132,9 +134,8 @@ abstract class Template
     {
         $stack = new Context(null, $this->mustache->useBuggyPropertyShadowing());
 
-        $helpers = $this->mustache->getHelpers();
-        if (! $helpers->isEmpty()) {
-            $stack->push($helpers);
+        if (! $this->helpers->isEmpty()) {
+            $stack->push($this->helpers);
         }
 
         if (! empty($context)) {

--- a/src/Template.php
+++ b/src/Template.php
@@ -49,7 +49,7 @@ abstract class Template
      *
      * @return string Rendered template
      */
-    final public function render(mixed $context = []): string
+    public function render(mixed $context = []): string
     {
         return $this->renderInternal(
             $this->prepareContextStack($context),

--- a/src/Template.php
+++ b/src/Template.php
@@ -12,21 +12,15 @@ use function is_callable;
 use function is_object;
 use function is_string;
 
-/**
- * Abstract Mustache Template class.
- *
- * @abstract
- */
 abstract class Template
 {
-    protected bool $strictCallables = false;
-
     /**
      * Mustache Template constructor.
      */
-    public function __construct(
+    final public function __construct(
         protected Engine $mustache,
         protected HelperCollection $helpers,
+        protected bool $strictCallables,
     ) {
     }
 
@@ -43,7 +37,7 @@ abstract class Template
      *
      * @return string Rendered template
      */
-    public function __invoke(mixed $context = []): string
+    final public function __invoke(mixed $context = []): string
     {
         return $this->render($context);
     }
@@ -55,7 +49,7 @@ abstract class Template
      *
      * @return string Rendered template
      */
-    public function render(mixed $context = []): string
+    final public function render(mixed $context = []): string
     {
         return $this->renderInternal(
             $this->prepareContextStack($context),

--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -21,7 +21,7 @@ use function trim;
  *
  * This class is responsible for turning raw template source into a set of Mustache tokens.
  */
-class Tokenizer
+final class Tokenizer
 {
     // Finite state machine states
     private const IN_TEXT = 0;

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -66,7 +66,6 @@ class EngineTest extends FunctionalTestCase
         $this->assertTrue($mustache->hasHelper('foo'));
         $this->assertTrue($mustache->hasHelper('bar'));
         $this->assertFalse($mustache->hasHelper('baz'));
-        $this->assertEquals([Engine::PRAGMA_FILTERS], $mustache->getPragmas());
     }
 
     public static function getFoo(): string

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -11,7 +11,6 @@ use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Mustache\Cache\FilesystemCache;
 use Mustache\Cache\NoopCache;
-use Mustache\Compiler;
 use Mustache\Engine;
 use Mustache\Exception\InvalidArgumentException;
 use Mustache\Exception\RuntimeException;
@@ -104,7 +103,6 @@ class EngineTest extends FunctionalTestCase
     {
         $logger    = new NullLogger();
         $loader    = new StringLoader();
-        $compiler  = new Compiler();
         $mustache  = new Engine();
         $cache     = new FilesystemCache(self::$tempDir);
 
@@ -119,10 +117,6 @@ class EngineTest extends FunctionalTestCase
         $this->assertNotSame($loader, $mustache->getPartialsLoader());
         $mustache->setPartialsLoader($loader);
         $this->assertSame($loader, $mustache->getPartialsLoader());
-
-        $this->assertNotSame($compiler, $mustache->getCompiler());
-        $mustache->setCompiler($compiler);
-        $this->assertSame($compiler, $mustache->getCompiler());
 
         $this->assertNotSame($cache, $mustache->getCache());
         $mustache->setCache($cache);

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -21,7 +21,6 @@ use Mustache\Loader\StringLoader;
 use Mustache\Parser;
 use Mustache\Template;
 use Mustache\Test\Asset\EngineStub;
-use Mustache\Tokenizer;
 use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
 
@@ -106,7 +105,6 @@ class EngineTest extends FunctionalTestCase
     {
         $logger    = new NullLogger();
         $loader    = new StringLoader();
-        $tokenizer = new Tokenizer();
         $parser    = new Parser();
         $compiler  = new Compiler();
         $mustache  = new Engine();
@@ -123,10 +121,6 @@ class EngineTest extends FunctionalTestCase
         $this->assertNotSame($loader, $mustache->getPartialsLoader());
         $mustache->setPartialsLoader($loader);
         $this->assertSame($loader, $mustache->getPartialsLoader());
-
-        $this->assertNotSame($tokenizer, $mustache->getTokenizer());
-        $mustache->setTokenizer($tokenizer);
-        $this->assertSame($tokenizer, $mustache->getTokenizer());
 
         $this->assertNotSame($parser, $mustache->getParser());
         $mustache->setParser($parser);

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -184,6 +184,7 @@ class EngineTest extends FunctionalTestCase
                 'foo' => $foo,
                 'bar' => $bar,
             ],
+            'strict_callables' => false,
         ]);
 
         $helpers = $mustache->getHelpers();

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -55,7 +55,6 @@ class EngineTest extends FunctionalTestCase
             'pragmas'      => [Engine::PRAGMA_FILTERS],
         ]);
 
-        $this->assertSame($logger, $mustache->getLogger());
         $this->assertSame($loader, $mustache->getLoader());
         $this->assertSame($partialsLoader, $mustache->getPartialsLoader());
         $this->assertEquals('{{ foo }}', $partialsLoader->load('foo'));
@@ -97,13 +96,8 @@ class EngineTest extends FunctionalTestCase
 
     public function testSettingServices(): void
     {
-        $logger    = new NullLogger();
         $loader    = new StringLoader();
         $mustache  = new Engine();
-
-        $this->assertNotSame($logger, $mustache->getLogger());
-        $mustache->setLogger($logger);
-        $this->assertSame($logger, $mustache->getLogger());
 
         $this->assertNotSame($loader, $mustache->getLoader());
         $mustache->setLoader($loader);

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -55,8 +55,6 @@ class EngineTest extends FunctionalTestCase
             'pragmas'      => [Engine::PRAGMA_FILTERS],
         ]);
 
-        $this->assertSame($loader, $mustache->getLoader());
-        $this->assertSame($partialsLoader, $mustache->getPartialsLoader());
         $this->assertEquals('{{ foo }}', $partialsLoader->load('foo'));
         $this->assertStringContainsString('__whot__', $mustache->getTemplateClassName('{{ foo }}'));
         $this->assertEquals('strtoupper', $mustache->getEscape());
@@ -92,20 +90,6 @@ class EngineTest extends FunctionalTestCase
 
         $this->assertEquals($output, $mustache->render($source, $data));
         $this->assertEquals($source, $mustache->source);
-    }
-
-    public function testSettingServices(): void
-    {
-        $loader    = new StringLoader();
-        $mustache  = new Engine();
-
-        $this->assertNotSame($loader, $mustache->getLoader());
-        $mustache->setLoader($loader);
-        $this->assertSame($loader, $mustache->getLoader());
-
-        $this->assertNotSame($loader, $mustache->getPartialsLoader());
-        $mustache->setPartialsLoader($loader);
-        $this->assertSame($loader, $mustache->getPartialsLoader());
     }
 
     /** @group functional */

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -58,7 +58,6 @@ class EngineTest extends FunctionalTestCase
         $this->assertEquals('{{ foo }}', $partialsLoader->load('foo'));
         $this->assertStringContainsString('__whot__', $mustache->getTemplateClassName('{{ foo }}'));
         $this->assertEquals('strtoupper', $mustache->getEscape());
-        $this->assertEquals(ENT_QUOTES, $mustache->getEntityFlags());
         $this->assertEquals('ISO-8859-1', $mustache->getCharset());
         $this->assertTrue($mustache->hasHelper('foo'));
         $this->assertTrue($mustache->hasHelper('bar'));

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -18,7 +18,6 @@ use Mustache\Exception\RuntimeException;
 use Mustache\Loader\ArrayLoader;
 use Mustache\Loader\ProductionFilesystemLoader;
 use Mustache\Loader\StringLoader;
-use Mustache\Parser;
 use Mustache\Template;
 use Mustache\Test\Asset\EngineStub;
 use Psr\Log\LogLevel;
@@ -105,7 +104,6 @@ class EngineTest extends FunctionalTestCase
     {
         $logger    = new NullLogger();
         $loader    = new StringLoader();
-        $parser    = new Parser();
         $compiler  = new Compiler();
         $mustache  = new Engine();
         $cache     = new FilesystemCache(self::$tempDir);
@@ -121,10 +119,6 @@ class EngineTest extends FunctionalTestCase
         $this->assertNotSame($loader, $mustache->getPartialsLoader());
         $mustache->setPartialsLoader($loader);
         $this->assertSame($loader, $mustache->getPartialsLoader());
-
-        $this->assertNotSame($parser, $mustache->getParser());
-        $mustache->setParser($parser);
-        $this->assertSame($parser, $mustache->getParser());
 
         $this->assertNotSame($compiler, $mustache->getCompiler());
         $mustache->setCompiler($compiler);

--- a/test/Mustache/Test/Functional/ExamplesTest.php
+++ b/test/Mustache/Test/Functional/ExamplesTest.php
@@ -33,6 +33,7 @@ class ExamplesTest extends TestCase
     {
         $mustache = new Engine([
             'partials' => $partials,
+            'strict_callables' => false,
         ]);
         $this->assertEquals($expected, $mustache->loadTemplate($source)->render($context));
     }

--- a/test/Mustache/Test/Functional/HigherOrderSectionsTest.php
+++ b/test/Mustache/Test/Functional/HigherOrderSectionsTest.php
@@ -25,7 +25,9 @@ class HigherOrderSectionsTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        $this->mustache = new Engine();
+        $this->mustache = new Engine([
+            'strict_callables' => false,
+        ]);
     }
 
     /** @dataProvider sectionCallbackData */
@@ -93,6 +95,9 @@ class HigherOrderSectionsTest extends FunctionalTestCase
     public function testPassThroughOptimization(): void
     {
         $builder = $this->getMockBuilder(Engine::class);
+        $builder->setConstructorArgs([
+            ['strict_callables' => false],
+        ]);
         $builder->onlyMethods(['loadLambda']);
         $mustache = $builder->getMock();
         $mustache->expects($this->never())
@@ -109,6 +114,9 @@ class HigherOrderSectionsTest extends FunctionalTestCase
     public function testWithoutPassThroughOptimization(): void
     {
         $builder = $this->getMockBuilder(Engine::class);
+        $builder->setConstructorArgs([
+            ['strict_callables' => false],
+        ]);
         $builder->onlyMethods(['loadLambda']);
         $mustache = $builder->getMock();
         $mustache->expects(self::once())
@@ -140,6 +148,7 @@ class HigherOrderSectionsTest extends FunctionalTestCase
             'template_class_prefix'  => $tplPrefix,
             'cache'                  => $cache,
             'cache_lambda_templates' => $enable,
+            'strict_callables' => false,
         ]);
 
         $tpl = $mustache->loadTemplate('{{#wrap}}{{name}}{{/wrap}}');

--- a/test/Mustache/Test/Functional/HigherOrderSectionsTest.php
+++ b/test/Mustache/Test/Functional/HigherOrderSectionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mustache\Test\Functional;
 
+use Mustache\Cache\FilesystemCache;
 use Mustache\Engine;
 use Mustache\Test\Functional\HigherOrderSections\Foo;
 use Mustache\Test\Functional\HigherOrderSections\Monster;
@@ -122,7 +123,11 @@ class HigherOrderSectionsTest extends FunctionalTestCase
         $this->assertEquals('<em>' . $foo->name . '</em>', $tpl->render($foo));
     }
 
-    /** @dataProvider cacheLambdaTemplatesData */
+    /**
+     * @param non-empty-string $tplPrefix
+     *
+     * @dataProvider cacheLambdaTemplatesData
+     */
     public function testCacheLambdaTemplatesOptionWorks(
         string $dirName,
         string $tplPrefix,
@@ -130,9 +135,10 @@ class HigherOrderSectionsTest extends FunctionalTestCase
         int $expect,
     ): void {
         $cacheDir = $this->setUpCacheDir($dirName);
+        $cache = new FilesystemCache($cacheDir);
         $mustache = new Engine([
             'template_class_prefix'  => $tplPrefix,
-            'cache'                  => $cacheDir,
+            'cache'                  => $cache,
             'cache_lambda_templates' => $enable,
         ]);
 
@@ -143,7 +149,7 @@ class HigherOrderSectionsTest extends FunctionalTestCase
         $this->assertCount($expect, glob($cacheDir . '/*.php'));
     }
 
-    /** @return list<array{0: string, 1: string, 2: bool, 3: int}> */
+    /** @return list<array{0: string, 1: non-empty-string, 2: bool, 3: int}> */
     public static function cacheLambdaTemplatesData(): array
     {
         return [

--- a/test/Mustache/Test/Functional/MustacheInjectionTest.php
+++ b/test/Mustache/Test/Functional/MustacheInjectionTest.php
@@ -17,7 +17,9 @@ class MustacheInjectionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mustache = new Engine();
+        $this->mustache = new Engine([
+            'strict_callables' => false,
+        ]);
     }
 
     /**

--- a/test/Mustache/Test/HelperCollectionTest.php
+++ b/test/Mustache/Test/HelperCollectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mustache\Test;
 
 use Mustache\Exception\InvalidArgumentException;
+use Mustache\Exception\UnknownHelperException;
 use Mustache\HelperCollection;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -15,7 +16,7 @@ class HelperCollectionTest extends TestCase
 {
     public function testConstructor(): void
     {
-        $foo = [$this, 'getFoo'];
+        $foo = static fn (): string => 'foo';
         $bar = 'BAR';
 
         $helpers = new HelperCollection([
@@ -27,14 +28,60 @@ class HelperCollectionTest extends TestCase
         $this->assertSame($bar, $helpers->get('bar'));
     }
 
-    public static function getFoo(): void
+    public function testHelpersCanBeAddedAtRuntime(): void
     {
-        echo 'foo';
+        $foo = static fn (): string => 'foo';
+        $helpers = new HelperCollection();
+        $helpers->add('foo', $foo);
+
+        self::assertSame($foo, $helpers->get('foo'));
+    }
+
+    public function testHelpersCanBeRemovedAtRuntime(): void
+    {
+        $foo = static fn (): string => 'foo';
+        $helpers = new HelperCollection([
+            'foo' => $foo,
+        ]);
+
+        $helpers->remove('foo');
+        $this->expectException(UnknownHelperException::class);
+        self::assertNull($helpers->get('foo'));
+    }
+
+    public function testHelperExistenceCanBeQueried(): void
+    {
+        $foo = static fn (): string => 'foo';
+        $helpers = new HelperCollection([
+            'foo' => $foo,
+        ]);
+
+        self::assertTrue($helpers->has('foo'));
+        self::assertFalse($helpers->has('bar'));
+    }
+
+    public function testHelpersCanBeEmpty(): void
+    {
+        self::assertTrue(
+            (new HelperCollection())->isEmpty(),
+        );
+    }
+
+    public function testHelpersCanBeEmptied(): void
+    {
+        $foo = static fn (): string => 'foo';
+        $helpers = new HelperCollection([
+            'foo' => $foo,
+        ]);
+
+        $helpers->clear();
+        self::assertTrue($helpers->isEmpty());
+        self::assertFalse($helpers->has('foo'));
     }
 
     public function testAccessorsAndMutators(): void
     {
-        $foo = [$this, 'getFoo'];
+        $foo = static fn (): string => 'foo';
         $bar = 'BAR';
 
         $helpers = new HelperCollection();
@@ -60,7 +107,7 @@ class HelperCollectionTest extends TestCase
 
     public function testMagicMethods(): void
     {
-        $foo = [$this, 'getFoo'];
+        $foo = static fn (): string => 'foo';
         $bar = 'BAR';
 
         $helpers = new HelperCollection();

--- a/test/Mustache/Test/TemplateTest.php
+++ b/test/Mustache/Test/TemplateTest.php
@@ -6,6 +6,7 @@ namespace Mustache\Test;
 
 use Mustache\Context;
 use Mustache\Engine;
+use Mustache\HelperCollection;
 use PHPUnit\Framework\TestCase;
 
 class TemplateTest extends TestCase
@@ -13,7 +14,7 @@ class TemplateTest extends TestCase
     public function testConstructor(): void
     {
         $mustache = new Engine();
-        $template = new TemplateStub($mustache);
+        $template = new TemplateStub($mustache, new HelperCollection());
         $this->assertSame($mustache, $template->getMustache());
     }
 
@@ -21,7 +22,7 @@ class TemplateTest extends TestCase
     {
         $rendered = '<< wheee >>';
         $mustache = new Engine();
-        $template = new TemplateStub($mustache);
+        $template = new TemplateStub($mustache, new HelperCollection());
         $template->rendered = $rendered;
         $context  = new Context();
 

--- a/test/Mustache/Test/TemplateTest.php
+++ b/test/Mustache/Test/TemplateTest.php
@@ -14,7 +14,7 @@ class TemplateTest extends TestCase
     public function testConstructor(): void
     {
         $mustache = new Engine();
-        $template = new TemplateStub($mustache, new HelperCollection());
+        $template = new TemplateStub($mustache, new HelperCollection(), true);
         $this->assertSame($mustache, $template->getMustache());
     }
 
@@ -22,7 +22,7 @@ class TemplateTest extends TestCase
     {
         $rendered = '<< wheee >>';
         $mustache = new Engine();
-        $template = new TemplateStub($mustache, new HelperCollection());
+        $template = new TemplateStub($mustache, new HelperCollection(), true);
         $template->rendered = $rendered;
         $context  = new Context();
 


### PR DESCRIPTION
- Remove set/get Tokenizer
- Remove set/get Parser
- Remove set/get Compiler
- Remove set/get Cache
- Remove set/get Logger
- Remove set/get Loader
- Remove set/get PartialsLoader
- Remove set/get Helpers alongs with `addHelper`, `removeHelper`
- Default "strict callables" to true
- Prevent public read of current pragmas
- Default entity flags to current PHP default and drop `getEntityFlags`