### PR TITLE
Remove `buggyPropertyShadowing` property, accessors and affordances.

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -33,10 +33,9 @@ final class Context
     /**
      * Mustache rendering Context constructor.
      *
-     * @param mixed $context                Default rendering context (default: null)
-     * @param bool $buggyPropertyShadowing See Mustache\Engine::useBuggyPropertyShadowing (default: false)
+     * @param mixed $context Default rendering context (default: null)
      */
-    public function __construct(mixed $context = null, private bool $buggyPropertyShadowing = false)
+    public function __construct(mixed $context = null)
     {
         if ($context === null) {
             return;
@@ -237,24 +236,15 @@ final class Context
                             return $frame->$id;
                         }
 
-                        // Preserve backwards compatibility with a property shadowing bug in
-                        // Mustache.php <= 2.14.2
-                        // See https://github.com/bobthecow/mustache.php/pull/410
-                        if ($this->buggyPropertyShadowing) {
-                            if ($frame instanceof ArrayAccess && isset($frame[$id])) {
-                                return $frame[$id];
+                        if (property_exists($frame, $id)) {
+                            $rp = new ReflectionProperty($frame, $id);
+                            if ($rp->isPublic()) {
+                                return $frame->$id;
                             }
-                        } else {
-                            if (property_exists($frame, $id)) {
-                                $rp = new ReflectionProperty($frame, $id);
-                                if ($rp->isPublic()) {
-                                    return $frame->$id;
-                                }
-                            }
+                        }
 
-                            if ($frame instanceof ArrayAccess && $frame->offsetExists($id)) {
-                                return $frame[$id];
-                            }
+                        if ($frame instanceof ArrayAccess && $frame->offsetExists($id)) {
+                            return $frame[$id];
                         }
                     }
 

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -52,7 +52,6 @@ use const ENT_SUBSTITUTE;
  *     logger?: LoggerInterface,
  *     strict_callables?: bool,
  *     pragmas?: list<Engine::PRAGMA_*>,
- *     buggy_property_shadowing?: bool,
  * }
  */
 class Engine
@@ -89,7 +88,6 @@ class Engine
     /** @var array<self::PRAGMA_*, bool> */
     private array $pragmas = [];
     private string|null $delimiters = null;
-    private bool $buggyPropertyShadowing = false;
     // Services
     private readonly Tokenizer $tokenizer;
     private readonly Parser $parser;
@@ -235,8 +233,6 @@ class Engine
 
             $this->pragmas[$pragma] = true;
         }
-
-        $this->buggyPropertyShadowing = $options['buggy_property_shadowing'] ?? false;
     }
 
     /**
@@ -270,16 +266,6 @@ class Engine
     public function getCharset(): string
     {
         return $this->charset;
-    }
-
-    /**
-     * Check whether to use buggy property shadowing.
-     *
-     * See https://github.com/bobthecow/mustache.php/pull/410
-     */
-    public function useBuggyPropertyShadowing(): bool
-    {
-        return $this->buggyPropertyShadowing;
     }
 
     /**

--- a/src/Template.php
+++ b/src/Template.php
@@ -126,7 +126,7 @@ abstract class Template
      */
     protected function prepareContextStack(mixed $context = null): Context
     {
-        $stack = new Context(null, $this->mustache->useBuggyPropertyShadowing());
+        $stack = new Context(null);
 
         if (! $this->helpers->isEmpty()) {
             $stack->push($this->helpers);

--- a/test/Mustache/Test/ContextTest.php
+++ b/test/Mustache/Test/ContextTest.php
@@ -212,21 +212,4 @@ class ContextTest extends TestCase
 
         $this->assertNull($context->find('name'));
     }
-
-    public function testBuggyNullPropertyValueMasking(): void
-    {
-        $context = new Context(null, true);
-
-        $a = (object) [
-            'name' => 'not null',
-        ];
-        $b = (object) [
-            'name' => null,
-        ];
-
-        $context->push($a);
-        $context->push($b);
-
-        $this->assertEquals($context->find('name'), 'not null');
-    }
 }

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -355,15 +355,6 @@ class EngineTest extends FunctionalTestCase
         $this->assertEquals('b', $tpl->render(['a' => 'b']));
     }
 
-    public function testBuggyPropertyShadowing(): void
-    {
-        $mustache = new Engine();
-        $this->assertFalse($mustache->useBuggyPropertyShadowing());
-
-        $mustache = new Engine(['buggy_property_shadowing' => true]);
-        $this->assertTrue($mustache->useBuggyPropertyShadowing());
-    }
-
     /**
      * @param list<Engine::PRAGMA_*> $pragmas
      * @param array<string, mixed> $helpers


### PR DESCRIPTION
This means that models appended to the stack will overwrite previous props with the same name when the value is null: i.e.

$context->push(['foo' => 'bar']);
$context->push(['foo' => null]);
$context->find('foo'); // null